### PR TITLE
日付の取得方法を変更

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,5 @@
 import { Member } from "@/app/api/route";
-import {
-  addMonths,
-  eachDayOfInterval,
-  format,
-  getMonth,
-  getYear,
-  isMonday,
-} from "date-fns";
+import { eachDayOfInterval, format, isMonday } from "date-fns";
 import { ja } from "date-fns/locale";
 
 async function getMemberData() {
@@ -45,12 +38,9 @@ const MemberCell = ({ name }: { name: string }) => {
 export default async function Home() {
   const memberData: { members: Member[] } = await getMemberData();
 
-  const today = new Date();
-  const thisMonth = getMonth(today) + 1;
-  const thisYear = getYear(today);
   const mondays = eachDayOfInterval({
-    start: new Date(`${thisYear}-${thisMonth}-01`),
-    end: addMonths(new Date(`${thisYear}-${thisMonth}-31`), 2),
+    start: new Date("2025-08-01"),
+    end: new Date("2026-12-31"),
   })
     .filter((day) => isMonday(day))
     .map((date) => format(date, "yyyy/M/d(E)", { locale: ja }));

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,11 @@
 import { Member } from "@/app/api/route";
-import { eachDayOfInterval, format, isMonday } from "date-fns";
+import {
+  eachDayOfInterval,
+  format,
+  isBefore,
+  isMonday,
+  startOfDay,
+} from "date-fns";
 import { ja } from "date-fns/locale";
 
 async function getMemberData() {
@@ -67,7 +73,15 @@ export default async function Home() {
             {mondays.map(
               (monday, index) =>
                 index < memberData.members.length && (
-                  <li key={monday}>
+                  <li
+                    key={monday}
+                    className={
+                      // mondayが今日以前であればグレーアウト
+                      isBefore(monday, startOfDay(new Date()))
+                        ? "bg-gray-300"
+                        : ""
+                    }
+                  >
                     <span>{index % memberData.members.length}:</span>
                     <time dateTime={monday}>{monday}</time>
                   </li>


### PR DESCRIPTION
close #22 #16

## やったこと
- `2025/08/01` を起点に `2026/12/31` まで取得（表示は1周分）
- 過去の日付はグレーアウトする

## やってないこと
- `end: new Date("2026-12-31")` は手動で更新する必要がある